### PR TITLE
Update stadt dependency version

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -25,6 +25,6 @@
     "estree-walker": "^0.6.0",
     "glob": "^7.1.3",
     "immutable": "^4.0.0-rc.12",
-    "stadt": "https://github.com/returntocorp/stadt#5a559ba"
+    "stadt": "^0.2.0"
   }
 }


### PR DESCRIPTION
I wasn't able to run `r2c run` until I changed the `stadt` dependency in package.json

the error was:
```
Step 8/10 : RUN npm run-script build               
 ---> Running in 2c8cf9f803db                       
                                                   
> r2c-typed-ast-rules@0.6.0 build /analyzer                                 
> tsc                                                       
    
src/rules/index.ts(4,24): error TS2307: Cannot find module 'stadt'.
src/rules/non-literal-require.ts(2,24): error TS2307: Cannot find module 'stadt'.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! r2c-typed-ast-rules@0.6.0 build: `tsc`         
npm ERR! Exit status 2
npm ERR!                                            
npm ERR! Failed at the r2c-typed-ast-rules@0.6.0 build script.                                                                                                          
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```